### PR TITLE
Fixing some types

### DIFF
--- a/src/theme/M3/types/ThemeTokens.ts
+++ b/src/theme/M3/types/ThemeTokens.ts
@@ -66,20 +66,20 @@ export type ThemeTokens = {
     background: string;
     onBackground: string;
 
-    info?: string;
-    onInfo?: string;
-    infoContainer?: string;
-    onInfoContainer?: string;
+    info: string;
+    onInfo: string;
+    infoContainer: string;
+    onInfoContainer: string;
 
-    success?: string;
-    onSuccess?: string;
-    successContainer?: string;
-    onSuccessContainer?: string;
+    success: string;
+    onSuccess: string;
+    successContainer: string;
+    onSuccessContainer: string;
 
-    warning?: string;
-    onWarning?: string;
-    warningContainer?: string;
-    onWarningContainer?: string;
+    warning: string;
+    onWarning: string;
+    warningContainer: string;
+    onWarningContainer: string;
 }
 
 export const LightTokensDefault: ThemeTokens = {

--- a/src/theme/M3/utils/getMUIPalette.ts
+++ b/src/theme/M3/utils/getMUIPalette.ts
@@ -9,8 +9,7 @@ declare module '@mui/material/styles/createTheme' {
 }
 
 declare module '@mui/material/styles/createPalette' {
-    interface Palette {
-        [index: string]: PaletteColor;
+    interface M3Palette {
         //primary: PaletteColor;
         onPrimary: PaletteColor;
         primaryContainer: PaletteColor;
@@ -64,10 +63,10 @@ declare module '@mui/material/styles/createPalette' {
         outline: PaletteColor;
         outlineVariant: PaletteColor;
 
-        inverseSurface: PaletteColor;
-        inverseOnSurface: PaletteColor;
         inversePrimary: PaletteColor;
         inverseOnPrimary: PaletteColor;
+        inverseSurface: PaletteColor;
+        inverseOnSurface: PaletteColor;
 
         shadow: PaletteColor;
         scrim: PaletteColor;
@@ -92,9 +91,19 @@ declare module '@mui/material/styles/createPalette' {
         warningContainer: PaletteColor;
         onWarningContainer: PaletteColor;
     }
+
+    interface M3PaletteOptions extends Record<keyof M3Palette, PaletteColorOptions>{
+        themeMode: string;
+    }
+
+    interface Palette extends M3Palette {
+    }
+
+    interface PaletteOptions extends M3PaletteOptions {
+    }
 }
 
-export const getMUIPalette = (themeMode: ThemeMode, themescheme: ThemeScheme) => {
+export const getMUIPalette = (themeMode: ThemeMode, themescheme: ThemeScheme): ThemeOptions => {
     const scheme = themescheme[themeMode];
     return {
         palette: {
@@ -244,7 +253,7 @@ export const getMUIPalette = (themeMode: ThemeMode, themescheme: ThemeScheme) =>
             },
             onSurfaceVariant: {
                 main: scheme.onSurfaceVariant,
-                contranstText: scheme.surfaceVariant
+                contrastText: scheme.surfaceVariant
             },
 
             outline: {
@@ -353,5 +362,5 @@ export const getMUIPalette = (themeMode: ThemeMode, themescheme: ThemeScheme) =>
             divider: scheme.outline
         },
         tones: themescheme.tones
-    } as ThemeOptions;
+    };
 }


### PR DESCRIPTION
There was a typo `contranstText` in the code. This got through because the function `getMUIPalette` had too broad typing. I've tried fixing them here.

I couldn't get the project to build or lint though, so this might be wrong. The `main.tsx` file is importing `import M3 from './Theme/M3/M3';` with a capital T which doesn't match the folder, and some other files are doing that too. I didn't try to fix further since I assume I'm missing something here.